### PR TITLE
Fix Node 20 deprecation warning in Actions, add github-actions to dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,69 +5,93 @@ updates:
     schedule:
       interval: "monthly"
     groups:
-      all-dependencies:
+      minor-and-patch:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "npm"
     directory: "apps/ui"
     schedule:
       interval: "monthly"
     groups:
-      all-dependencies:
+      minor-and-patch:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "npm"
     directory: "tests/ui"
     schedule:
       interval: "monthly"
     groups:
-      all-dependencies:
+      minor-and-patch:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "helm"
     directory: "configs/helm"
     schedule:
       interval: "monthly"
     groups:
-      all-dependencies:
+      minor-and-patch:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "docker"
     directory: "apps/api"
     schedule:
       interval: "monthly"
     groups:
-      all-dependencies:
+      minor-and-patch:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "docker"
     directory: "apps/ui"
     schedule:
       interval: "monthly"
     groups:
-      all-dependencies:
+      minor-and-patch:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "docker"
     directory: "apps/k6"
     schedule:
       interval: "monthly"
     groups:
-      all-dependencies:
+      minor-and-patch:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
     groups:
-      all-dependencies:
+      minor-and-patch:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -17,11 +17,6 @@ updates:
       all-dependencies:
         patterns:
           - "*"
-    
-    ignore:
-      - dependency-name: "typescript"
-        versions:
-          - ">=5.9.0"
 
   - package-ecosystem: "npm"
     directory: "tests/ui"
@@ -61,6 +56,15 @@ updates:
 
   - package-ecosystem: "docker"
     directory: "apps/k6"
+    schedule:
+      interval: "monthly"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "monthly"
     groups:

--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Approve PR if Dependabot is the creator
         if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}

--- a/.github/workflows/eks-create-cluster.yaml
+++ b/.github/workflows/eks-create-cluster.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Write .env file
         run: |

--- a/.github/workflows/eks-delete-cluster.yaml
+++ b/.github/workflows/eks-delete-cluster.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Write .env file
         run: |

--- a/.github/workflows/quality-gate.yaml
+++ b/.github/workflows/quality-gate.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: true
           fetch-depth: 0
@@ -59,7 +59,7 @@ jobs:
         run: cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY
       - name: Post Coverage Comment to PR
         if: github.event_name == 'pull_request'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-file: code-coverage-results.md
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: true
           fetch-depth: 0
@@ -102,7 +102,7 @@ jobs:
         run: cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY
       - name: Post Coverage Comment to PR
         if: github.event_name == 'pull_request'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-file: code-coverage-results.md
@@ -124,7 +124,7 @@ jobs:
       - name: Clean up workspace
         run: rm -rf $GITHUB_WORKSPACE/*
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: true
       - name: Write .env file
@@ -197,7 +197,7 @@ jobs:
           check_name: "Playwright UI Tests"
           files: ./tests/ui/test-results/results.xml
       - name: Archive Playwright Test Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: report.zip


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout` (v3/v4 → v5), `actions/upload-artifact` (v4 → v6), and `peter-evans/create-or-update-comment` (v4 → v5) — all previously declared `node20` (checkout v3 declared `node16`), which GitHub now force-runs on Node 24 with a deprecation warning on every run.
- Adds a `github-actions` ecosystem entry to `dependabot.yaml` — it was missing entirely, which is how these went unnoticed. Actions will now get grouped monthly bumps like everything else.
- Drops the `typescript: >=5.9.0` ignore rule in the `apps/ui` npm ecosystem — it predates the Angular 22 upgrade (#268) and would have permanently blocked dependabot from ever proposing the TypeScript 6.x that Angular 22 now requires.
- `hadolint/hadolint-action` (Docker-based) and `EnricoMi/publish-unit-test-result-action` (composite) were left alone — neither declares its own Node runtime, so they're unaffected.

## Test plan
- [x] Diffed each action's `action.yml` at old vs. new version to confirm `using: node24`
- [ ] CI on this PR should run clean with no Node 20 deprecation annotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)