### PR TITLE
Fix secrets handling in setup/install scripts

### DIFF
--- a/scripts/helm/check-dot-env.sh
+++ b/scripts/helm/check-dot-env.sh
@@ -8,7 +8,8 @@ if [ ! -f $ENV_FILE ]; then
     echo -e "<root>/configs/.env file not found. Creating one now.\nYou can decide all values yourself.\nThey will be used automatically for all tools."
 
     read -p "Enter USERNAME_TOOLS: " USERNAME_TOOLS
-    read -p "Enter PASSWORD_TOOLS: " PASSWORD_TOOLS
+    read -s -p "Enter PASSWORD_TOOLS: " PASSWORD_TOOLS
+    echo
 
     cat <<EOF >$ENV_FILE
 USERNAME_TOOLS=$USERNAME_TOOLS

--- a/scripts/helm/install.sh
+++ b/scripts/helm/install.sh
@@ -39,8 +39,9 @@ setup_k8s_secrets() {
   kubectl create secret generic $APP_NAME-secrets --namespace $NAMESPACE --from-env-file="$ENV_FILE"
 
   kubectl delete secret basic-auth --namespace $NAMESPACE --ignore-not-found
-  printf "$USERNAME_TOOLS:$(openssl passwd -apr1 "$PASSWORD_TOOLS")\n" >"$AUTH_FILE"
+  printf '%s:%s\n' "$USERNAME_TOOLS" "$(openssl passwd -apr1 "$PASSWORD_TOOLS")" >"$AUTH_FILE"
   kubectl create secret generic basic-auth --namespace $NAMESPACE --from-file=auth="$AUTH_FILE"
+  rm -f "$AUTH_FILE"
 }
 
 clean_previous_installation() {

--- a/scripts/setup/prepare.sh
+++ b/scripts/setup/prepare.sh
@@ -3,12 +3,6 @@
 set -e
 set -o pipefail
 
-# Allow passwordless sudo for current user (if not already configured)
-if [ ! -f "/etc/sudoers.d/$(whoami)" ]; then
-  echo "$(whoami) ALL=(ALL) NOPASSWD:ALL" | sudo tee "/etc/sudoers.d/$(whoami)" >/dev/null
-  sudo chmod 0440 "/etc/sudoers.d/$(whoami)"
-fi
-
 # Update and upgrade system packages
 sudo apt update
 sudo apt upgrade -y


### PR DESCRIPTION
## Summary
Fixes three secrets-handling issues found in a full-repo review of the setup/install scripts:

- `scripts/setup/prepare.sh` granted the invoking user **permanent passwordless sudo** (`NOPASSWD:ALL` in `/etc/sudoers.d/$(whoami)`) as a side effect of one-time environment bootstrap. Removed — sudo's normal credential cache (a few minutes) already covers the handful of `sudo` calls later in the same script.
- `scripts/helm/check-dot-env.sh` read `PASSWORD_TOOLS` via plain `read -p`, echoing it to the terminal/scrollback. This value becomes the MinIO root password, Grafana admin password, and ingress basic-auth credential. Switched to `read -s`.
- `scripts/helm/install.sh` built the basic-auth htpasswd line via `printf "$USERNAME_TOOLS:...\n"`, using user-controlled input as the *format string* — a `%` in the username/password would corrupt or error. Switched to `printf '%s:%s\n' "$USERNAME_TOOLS" "..."`, and the plaintext `.auth` file is now removed immediately after the k8s secret is created from it.

Closes #286, #287, #288

## Test plan
- [x] `bash -n` on all three scripts
- [x] Manually verified the new `printf '%s:%s\n'` call preserves `%` characters in username/password instead of corrupting output
- [x] Confirmed `AUTH_FILE` isn't referenced anywhere else in `install.sh` after the new `rm -f`