### PR TITLE
Run API and k6 containers as non-root, pin k6 base images by digest

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -4,11 +4,19 @@ WORKDIR /app
 COPY . .
 RUN gradle clean bootJar --no-daemon
 
-FROM eclipse-temurin:25-jdk
+FROM eclipse-temurin:25-jre
 WORKDIR /app
 
+RUN groupadd -r app && useradd -r -g app app
+
 COPY --from=builder /app/build/libs/*.jar app.jar
+RUN chown app:app app.jar
+
+USER app
 
 EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=15s --retries=3 \
+  CMD bash -c 'echo > /dev/tcp/127.0.0.1/8080' || exit 1
 
 ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/apps/k6/Dockerfile
+++ b/apps/k6/Dockerfile
@@ -1,9 +1,10 @@
-FROM golang:1.26 AS builder
+FROM golang:1.26@sha256:f96cc555eb8db430159a3aa6797cd5bae561945b7b0fe7d0e284c63a3b291609 AS builder
 RUN go install go.k6.io/xk6/cmd/xk6@v1.4.6 && \
     xk6 build
 
-FROM alpine:3
-RUN apk add --no-cache ca-certificates aws-cli dos2unix
+FROM alpine:3@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+RUN apk add --no-cache ca-certificates aws-cli dos2unix && \
+    addgroup -S app && adduser -S -G app app
 COPY --from=builder /go/k6 /usr/local/bin/k6
 
 ARG PROMETHEUS_ADDR
@@ -14,8 +15,11 @@ ENV MINIO_SECRET_KEY=""
 ENV MINIO_BUCKET=""
 
 WORKDIR /app
+RUN chown app:app /app
 
-COPY run-test.sh /app/run-test.sh
-RUN dos2unix run-test.sh && chmod +x /app/run-test.sh
+COPY --chown=app:app run-test.sh /app/run-test.sh
+RUN dos2unix /app/run-test.sh && chmod +x /app/run-test.sh
+
+USER app
 
 ENTRYPOINT ["/bin/sh", "-c", "ls -a /app && /app/run-test.sh"]

--- a/apps/k6/example/run.sh
+++ b/apps/k6/example/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-go install go.k6.io/xk6/cmd/xk6@latest
+go install go.k6.io/xk6/cmd/xk6@v1.4.6
 xk6 build
 
 . ../../../configs/.env


### PR DESCRIPTION
## Summary
Fixes the Docker hygiene findings from a full-repo review:

- `apps/api/Dockerfile`: runtime stage ran as root on the full `-jdk` image with no healthcheck. Switched to `eclipse-temurin:25-jre` (smaller attack surface), added a dedicated non-root `app` user, and added a `HEALTHCHECK` that probes the app's listening port (no actuator dependency exists yet, so this uses bash's `/dev/tcp` rather than adding a new dependency).
- `apps/k6/Dockerfile`: ran as root and used floating `golang:1.26`/`alpine:3` tags. Pinned both by digest and added a dedicated non-root `app` user; `/app` is now owned by that user since `run-test.sh` downloads the test script there at runtime.
- `apps/k6/example/run.sh` installed `xk6@latest` while the production Dockerfile pins `xk6@v1.4.6` — aligned the example to the same pinned version.

Left as-is / out of scope: the Helm chart's kube-score suppressions for `container-security-context-user-group-id`/`readonlyrootfilesystem` (`configs/helm/templates/deployment.yaml:7`) live in the K8s manifest, not the image, so a Dockerfile `USER` alone doesn't satisfy them — that needs pod-level `securityContext` changes, tracked separately.

Closes #310, #311

## Test plan
- [x] Built both images locally (`docker build`) — succeed
- [x] `docker exec ... whoami` on the API container → `app` (non-root); healthcheck reaches `healthy` status
- [x] `docker run --entrypoint sh ... whoami/id` on the k6 image → `app` (non-root, uid 100); verified `/app` is writable by that user (needed for the MinIO test-file download step)