### PR TITLE
Fix stale docs/test-collection references, harden CI action pinning and auto-merge

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -16,17 +16,24 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - name: Approve PR if Dependabot is the creator
+      - name: Fetch Dependabot metadata
         if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+        id: metadata
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve PR if it's a safe (patch/minor) Dependabot update
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr review ${{ github.event.pull_request.number }} --approve --repo ${{ github.repository }}
 
-      - name: Merge PR if Dependabot is the creator
-        if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+      - name: Merge PR if it's a safe (patch/minor) Dependabot update
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/quality-gate.yaml
+++ b/.github/workflows/quality-gate.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           submodules: true
           fetch-depth: 0
@@ -29,7 +29,7 @@ jobs:
         working-directory: ./apps/api
         run: ./gradlew clean jacocoTestReport
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action/linux@v2
+        uses: EnricoMi/publish-unit-test-result-action/linux@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           check_name: "api Unit Tests"
@@ -45,7 +45,7 @@ jobs:
             -targetdir:coverage-report \
             -reporttypes:Cobertura
       - name: Generate Coverage Report Summary
-        uses: irongut/CodeCoverageSummary@v1.3.0
+        uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95 # v1.3.0
         with:
           filename: coverage-report/Cobertura.xml
           badge: true
@@ -59,7 +59,7 @@ jobs:
         run: cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY
       - name: Post Coverage Comment to PR
         if: github.event_name == 'pull_request'
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-file: code-coverage-results.md
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           submodules: true
           fetch-depth: 0
@@ -81,14 +81,14 @@ jobs:
         working-directory: ./apps/ui
         run: ./npmw run test:ci
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action/linux@v2
+        uses: EnricoMi/publish-unit-test-result-action/linux@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           check_name: "ui Unit Tests"
           files: |
             ./apps/ui/TESTS-Chrome_Headless_*.xml
       - name: Show Coverage Summary in PR
-        uses: irongut/CodeCoverageSummary@v1.3.0
+        uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95 # v1.3.0
         with:
           filename: ./apps/ui/coverage/thrash-buddy/coverage.xml
           badge: true
@@ -102,7 +102,7 @@ jobs:
         run: cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY
       - name: Post Coverage Comment to PR
         if: github.event_name == 'pull_request'
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-file: code-coverage-results.md
@@ -112,33 +112,45 @@ jobs:
         working-directory: ./apps/ui
         run: ./npmw run lint
 
+  k6:
+    name: k6 Analysis
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - name: Shellcheck
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
+        with:
+          scandir: "./apps/k6"
+          severity: warning
+
   infra-and-images:
     concurrency:
       group: "test--infra-group-${{ github.event.pull_request.number }}"
       cancel-in-progress: false
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' # takes too long for pushes
-    needs: [api, ui]
+    needs: [api, ui, k6]
     name: Infrastructure and Images
     runs-on: ubuntu-latest
     steps:
       - name: Clean up workspace
         run: rm -rf $GITHUB_WORKSPACE/*
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           submodules: true
       - name: Write .env file
         working-directory: ./configs
         run: echo "${{ secrets.DOT_ENV }}" > .env
-      - uses: hadolint/hadolint-action@v3.3.0
+      - uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
         with:
           dockerfile: ./apps/api/Dockerfile
           ignore: DL3018
-      - uses: hadolint/hadolint-action@v3.3.0
+      - uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
         with:
           dockerfile: ./apps/ui/Dockerfile
           ignore: DL3018
-      - uses: hadolint/hadolint-action@v3.3.0
+      - uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
         with:
           dockerfile: ./apps/k6/Dockerfile
           ignore: DL3018
@@ -191,13 +203,13 @@ jobs:
 
           trap "kill $PORT_FORWARD_PID" EXIT
       - name: Publish Playwright Test Results
-        uses: EnricoMi/publish-unit-test-result-action/linux@v2
+        uses: EnricoMi/publish-unit-test-result-action/linux@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           check_name: "Playwright UI Tests"
           files: ./tests/ui/test-results/results.xml
       - name: Archive Playwright Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: report.zip

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Thank you for your interest in contributing to **ThrashBuddy**! Your contributio
 
 ## Reporting Issues
 
-If you encounter any bugs or have suggestions for improvements, please [open an issue](https://github.com/besessener/ThrashBuddy/issues) on the repository. Provide as much detail as possible.
+If you encounter any bugs or have suggestions for improvements, please [open an issue](https://github.com/nobuddyorg/ThrashBuddy/issues) on the repository. Provide as much detail as possible.
 
 ---
 

--- a/docs/aws-eks.md
+++ b/docs/aws-eks.md
@@ -53,14 +53,14 @@ Once the cluster is created, the local Kubernetes context is switched accordingl
 ### Delete the Cluster
 
 ```shell
-./buddy aws delete-cluster
+./buddy.sh aws delete-cluster
 ```
 
 After deletion, the local Kubernetes context is restored.
-If you also want to get rid of the ECR repository and local docker images, you can run:
+If you also want to get rid of the ECR repository, you can run:
 
 ```shell
-./buddy aws cleanup
+./buddy.sh aws delete-ecr
 ```
 
 ### Pushing Docker Images to ECR
@@ -68,7 +68,7 @@ If you also want to get rid of the ECR repository and local docker images, you c
 AWS EKS requires Docker images to be uploaded to Amazon Elastic Container Registry (ECR). A preconfigured script is available for this:
 
 ```shell
-./buddy aws push-images
+./buddy.sh aws push-images
 ```
 
 This script is automatically executed during cluster creation via `create-cluster`. However, it can also be run later to update Docker images. The script runs:
@@ -87,7 +87,7 @@ After cluster creation, **ThrashBuddy** is accessible via its ingress IP, printe
 If your Kubernetes context switched in the meantime, you can reconnect to the EKS cluster again by running:
 
 ```shell
-./buddy aws connect-cluster
+./buddy.sh aws connect-cluster
 ```
 
 ## AWS Configuration Notes

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,7 +47,7 @@ The Docker images are built using predefined scripts in the project directory. T
 3. Navigate to the project root directory.
 4. Run the following script to build all images at once:
    ```shell
-   ./buddy docker build-all
+   ./buddy.sh docker build-all
    ```
 5. Verify the created images with:
    ```shell
@@ -70,14 +70,14 @@ A Kubernetes cluster is required to run ThrashBuddy. For local development, Dock
 2. **install into Kubernetes cluster:**
    Run the following script to start the cluster:
    ```shell
-   ./buddy helm install
+   ./buddy.sh helm install
    ```
 
 _NOTE_: When running this command in a Linux environment, e.g. with Minikube rather than Docker Desktop, you should set a port forwarding. Minikube cannot utilize the host network, unlike Docker on Windows. So for this you must first set a port with `export SUFFIX=:8080` and afterwards run `kubectl port-forward svc/ingress-nginx-controller 8080:80`. So the complete script would be:
 
 ```shell
 export SUFFIX=:8080
-./buddy helm install
+./buddy.sh helm install
 kubectl port-forward svc/ingress-nginx-controller 8080:80
 ```
 
@@ -132,7 +132,7 @@ With `Bruno` the API can be tested manually. It is not integrated in an automate
 
 To validate the entire application workflow — from frontend interactions to backend processing and InfluxDB operations — **End-to-End (E2E) tests** are implemented using **Playwright**. These tests simulate real user interactions with the UI to ensure all components function seamlessly together.
 
-The frontend E2E tests are located in the `services/frontend-test` directory and can be executed with the following commands:
+The frontend E2E tests are located in the `tests/ui` directory and can be executed with the following commands:
 
 ```bash
 ./npmw ci

--- a/tests/api/delete.bru
+++ b/tests/api/delete.bru
@@ -15,5 +15,11 @@ params:query {
 }
 
 body:multipart-form {
-  file: @file(C:\Repos\besessener\ThrashBuddy\services\k6\example\test.js) @contentType(multipart/form-data)
+  file: @file(../../apps/k6/example/test.js) @contentType(multipart/form-data)
+}
+
+tests {
+  test("status is 200", function () {
+    expect(res.getStatus()).to.equal(200);
+  });
 }

--- a/tests/api/start.bru
+++ b/tests/api/start.bru
@@ -18,3 +18,12 @@ body:json {
     "envVars": []
   }
 }
+
+tests {
+  test("status is 200 or 400", function () {
+    expect(res.getStatus()).to.be.oneOf([200, 400]);
+  });
+  test("response has a status field", function () {
+    expect(res.getBody()).to.have.property("status");
+  });
+}

--- a/tests/api/status.bru
+++ b/tests/api/status.bru
@@ -9,3 +9,12 @@ get {
   body: none
   auth: none
 }
+
+tests {
+  test("status is 200 or 500", function () {
+    expect(res.getStatus()).to.be.oneOf([200, 500]);
+  });
+  test("response has a status field", function () {
+    expect(res.getBody()).to.have.property("status");
+  });
+}

--- a/tests/api/stop.bru
+++ b/tests/api/stop.bru
@@ -9,3 +9,12 @@ post {
   body: none
   auth: none
 }
+
+tests {
+  test("status is 200 or 400", function () {
+    expect(res.getStatus()).to.be.oneOf([200, 400]);
+  });
+  test("response has a status field", function () {
+    expect(res.getBody()).to.have.property("status");
+  });
+}

--- a/tests/api/upload.bru
+++ b/tests/api/upload.bru
@@ -11,5 +11,11 @@ post {
 }
 
 body:multipart-form {
-  file: @file(.\..\..\services\k6\example\test.js) @contentType(multipart/form-data)
+  file: @file(../../apps/k6/example/test.js) @contentType(multipart/form-data)
+}
+
+tests {
+  test("status is 200", function () {
+    expect(res.getStatus()).to.equal(200);
+  });
 }


### PR DESCRIPTION
## Summary
Fixes the CI/docs/test-collection findings from a full-repo review:

**Docs**
- Every `./buddy ...` command in `docs/getting-started.md` and `docs/aws-eks.md` is fixed to `./buddy.sh ...` (only the README had it right before)
- `docs/aws-eks.md` documented a nonexistent `./buddy aws cleanup` command — replaced with the real `./buddy.sh aws delete-cluster` / `./buddy.sh aws delete-ecr`
- `docs/getting-started.md` pointed at a stale `services/frontend-test` directory for E2E tests — fixed to `tests/ui`
- `CONTRIBUTING.md` linked to the old GitHub org (`besessener`) — fixed to `nobuddyorg`

**Correction to my own earlier review**: I'd also flagged `docs/getting-started.md`'s claims about CodeQL/kube-conform/kube-score as describing nonexistent tooling. Verified that's wrong before "fixing" it — CodeQL runs via GitHub's default code scanning setup (not a committed workflow file, which is why grepping `.github/` for it found nothing), and kube-conform/kube-score genuinely run via `scripts/helm/test.sh` on every `./buddy.sh helm install`. Left that paragraph untouched.

**Bruno API test collection** (`tests/api/*.bru`)
- Fixed `upload.bru`/`delete.bru` file paths: one referenced a deleted `services/k6/example/` layout, the other a hardcoded Windows path under the old org name
- Added real status-code/body assertions to all five requests so `bru run` produces meaningful pass/fail instead of none at all (not wired into CI — the maintainer's docs note this was a deliberate choice, and actually wiring it up would need the requests reordered/chained, which is a bigger change than a hygiene fix)

**CI**
- Pinned every third-party GitHub Action to a commit SHA (with a version comment) instead of a floating tag, across both workflows
- Added a `k6` job (shellcheck via `ludeeus/action-shellcheck`) so all three apps get CI coverage, not just api/ui, and made the e2e job depend on it
- Gated Dependabot auto-merge on update type via `dependabot/fetch-metadata`: only patch/minor updates auto-approve/merge now, major bumps require manual review

Closes #296, #297, #298, #299, #300, #301, #302, #303, #304

## Test plan
- [x] Verified no remaining bare `./buddy ` (missing `.sh`) references anywhere in `docs/`
- [x] Both workflow YAML files parse successfully (`Psych`/`YAML.load_file`)
- [x] Ran `shellcheck` locally (via the `koalaman/shellcheck` image) against `apps/k6/run-test.sh` and `apps/k6/example/run.sh` with `severity: warning` — both clean
- [x] Verified every pinned action SHA resolves to the intended tag via `gh api repos/<owner>/<repo>/commits/<tag>`