### PR TITLE
Harden AWS/Helm scripts: fail on error, guard config sourcing, fix retry-loop false success

### DIFF
--- a/buddy.sh
+++ b/buddy.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 cd "$(dirname "$0")" || exit 1
 
 SCRIPTS_ROOT="./scripts"

--- a/scripts/aws/connect-cluster.sh
+++ b/scripts/aws/connect-cluster.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 # Description: Establish a connection to AWS EKS cluster (if created).
 
+set -e
+set -o pipefail
+
 pushd "$(dirname "$0")" >/dev/null
 
 . ./env.sh
-eksctl utils write-kubeconfig --cluster ${EKS_CLUSTER_NAME} && kubectl config use-context $(kubectl config get-contexts -o name | grep ${EKS_CLUSTER_NAME})
+eksctl utils write-kubeconfig --cluster "$EKS_CLUSTER_NAME" && kubectl config use-context "$(kubectl config get-contexts -o name | grep "$EKS_CLUSTER_NAME")"
 
 popd >/dev/null

--- a/scripts/aws/delete-cluster.sh
+++ b/scripts/aws/delete-cluster.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
 # Description: Delete an existing AWS cluster.
 
+set -e
+set -o pipefail
+
 pushd "$(dirname "$0")" >/dev/null
 
 . ./env.sh
 
 ../helm/uninstall.sh -remote
 
-eksctl utils write-kubeconfig --cluster ${EKS_CLUSTER_NAME} && kubectl config use-context $(kubectl config get-contexts -o name | grep ${EKS_CLUSTER_NAME})
-eksctl delete cluster --name $EKS_CLUSTER_NAME
+eksctl utils write-kubeconfig --cluster "$EKS_CLUSTER_NAME" && kubectl config use-context "$(kubectl config get-contexts -o name | grep "$EKS_CLUSTER_NAME")"
+eksctl delete cluster --name "$EKS_CLUSTER_NAME"
 
 popd >/dev/null

--- a/scripts/aws/delete-ecr.sh
+++ b/scripts/aws/delete-ecr.sh
@@ -1,14 +1,21 @@
 #!/bin/bash
 # Description: Delete all Docker images and ECR repositories related to the application.
 
+set -e
+set -o pipefail
+
 pushd "$(dirname "$0")" >/dev/null
 . ./env.sh
 
-docker images --format "{{.Repository}}:{{.Tag}}" | grep ^$APP_NAME/ | while read -r image; do
+images=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep "^$APP_NAME/" || true)
+echo "$images" | while read -r image; do
+  [ -z "$image" ] && continue
   docker rmi "$image" --force
 done
 
-aws ecr describe-repositories --query 'repositories[*].repositoryName' --output text | tr '\t' '\n' | grep ^$APP_NAME/ | while read -r repo; do
+repos=$(aws ecr describe-repositories --query 'repositories[*].repositoryName' --output text | tr '\t' '\n' | grep "^$APP_NAME/" || true)
+echo "$repos" | while read -r repo; do
+  [ -z "$repo" ] && continue
   echo "Deleting ECR repo: $repo"
   aws ecr delete-repository --repository-name "$repo" --force
 done

--- a/scripts/aws/push-images.sh
+++ b/scripts/aws/push-images.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Description: Push Docker images to AWS ECR (implicitly done with create-cluster).
 
+set -e
+set -o pipefail
+
 pushd "$(dirname "$0")" >/dev/null
 . ./env.sh
 
@@ -15,7 +18,10 @@ function login_ecr() {
 }
 
 function push_images() {
-  docker images --format "{{.Repository}}:{{.Tag}}" | grep "^$APP_NAME/" | while read -r image; do
+  local images
+  images=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep "^$APP_NAME/" || true)
+  echo "$images" | while read -r image; do
+    [ -z "$image" ] && continue
     image_name="${image%%:*}"
     image_tag="${image##*:}"
     target_image="$ECR_REPOSITORY/$image_name:$image_tag"

--- a/scripts/helm/install.sh
+++ b/scripts/helm/install.sh
@@ -75,15 +75,23 @@ install_and_run_tests() {
   xargs -I {} kubectl wait --for=condition=ready pod {} --namespace $NAMESPACE --timeout=300s
 
 
+  test_passed=false
   for i in {1..10}; do
     echo "Attempt $i/10 ..."
     sleep 10
-    if helm test $APP_NAME --namespace $NAMESPACE; then
+    if helm test "$APP_NAME" --namespace "$NAMESPACE"; then
+      test_passed=true
       break
     fi
   done
 
-  kubectl delete pod -l helm.sh/hook=test --namespace $NAMESPACE
+  kubectl delete pod -l helm.sh/hook=test --namespace "$NAMESPACE"
+
+  if [ "$test_passed" != true ]; then
+    echo "Integration test failed after 10 attempts." >&2
+    exit 1
+  fi
+
   echo "Integration test passed."
 }
 

--- a/scripts/helm/uninstall.sh
+++ b/scripts/helm/uninstall.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Description: [-remote] Uninstall all Helm charts (local or remote cluster).
 
+set -e
+set -o pipefail
+
 IS_REMOTE=false
 for arg in "$@"; do
     case "$arg" in
@@ -16,7 +19,7 @@ fi
 
 . ../setup/get-config.sh
 
-helm uninstall $APP_NAME --namespace $NAMESPACE || true
-helm uninstall ingress-nginx --namespace $NAMESPACE-ingress || true
+helm uninstall "$APP_NAME" --namespace "$NAMESPACE" || true
+helm uninstall ingress-nginx --namespace "$NAMESPACE-ingress" || true
 
 popd >/dev/null

--- a/scripts/setup/get-config.sh
+++ b/scripts/setup/get-config.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 
+set -e
+
 pushd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null
+
+for f in ../../configs/.env ../../configs/global.conf; do
+  if [ ! -f "$f" ]; then
+    echo "Error: required config file '$f' not found. If this is configs/.env, run './buddy.sh helm install' to create it interactively; otherwise verify you're running from a checkout of the repository." >&2
+    popd >/dev/null
+    exit 1
+  fi
+done
 
 set -a
 . ../../configs/.env


### PR DESCRIPTION
## Summary
Fixes the infra-script reliability findings from a full-repo review (the API-side reliability issues — async races, exception logging, resource leak, immutable image tags — are a separate follow-up once the in-flight API security PR merges, to avoid stacking changes on the same files mid-review):

- Added `set -e`/`set -o pipefail` to `buddy.sh` and every script that lacked it (`push-images.sh`, `delete-ecr.sh`, `connect-cluster.sh`, `delete-cluster.sh`, `uninstall.sh`) so a failed `docker push`/`login`/cluster operation is no longer silently swallowed and the script just carries on.
- That change has a sharp edge: `docker images | grep "^$APP_NAME/"` legitimately returns zero matches before the first build, and `pipefail` would turn that into a hard failure. Guarded those two pipelines (in `push-images.sh` and `delete-ecr.sh`) so an empty match list is a no-op, not an error.
- `get-config.sh` now checks that `configs/.env` and `configs/global.conf` exist before sourcing them, instead of silently continuing with empty `$APP_NAME`/`$NAMESPACE` — which `delete-ecr.sh` then uses (unquoted) to decide what to delete.
- `install.sh`'s `helm test` retry loop (10 attempts) now tracks whether any attempt actually succeeded and exits non-zero with a clear message if all 10 fail, instead of unconditionally printing "Integration test passed." regardless of outcome.
- Quoted a handful of previously-unquoted `$APP_NAME`/`$NAMESPACE`/`$EKS_CLUSTER_NAME` expansions in the lines touched above.

Closes #289, #290, #292

## Test plan
- [x] `bash -n` on every changed script
- [x] Manually verified `get-config.sh`: exits 1 with a clear message when `configs/.env` is missing, sources cleanly when both files are present
- [x] Manually verified the `push-images.sh`/`delete-ecr.sh` grep pipelines are a no-op (not a failure) when no matching images/repos exist, even under `pipefail`
- [x] `./buddy.sh` (no args) still prints the usage/help text correctly after adding `set -e`