### PR TITLE
Fix async status races, missing exception logging, and a resource leak in the API

### DIFF
--- a/apps/api/src/main/groovy/org/nobuddy/thrashbuddy/config/AsyncConfig.groovy
+++ b/apps/api/src/main/groovy/org/nobuddy/thrashbuddy/config/AsyncConfig.groovy
@@ -10,9 +10,12 @@ import java.util.concurrent.Executor
 @Configuration
 @EnableAsync
 class AsyncConfig {
+    // Only test start/stop ever run here (one at a time in practice, since
+    // TestExecutionService gates them on status) - a small fixed pool avoids
+    // the unbounded thread growth of newCachedThreadPool.
     @Bean(name = "blockingExecutor")
     Executor blockingExecutor() {
-        return Executors.newCachedThreadPool()
+        return Executors.newFixedThreadPool(2)
     }
 }
 

--- a/apps/api/src/main/groovy/org/nobuddy/thrashbuddy/service/FileService.groovy
+++ b/apps/api/src/main/groovy/org/nobuddy/thrashbuddy/service/FileService.groovy
@@ -24,7 +24,7 @@ class FileService {
     ResponseEntity<Map> handleUpload(MultipartFile file) {
         try {
             validateFileName(file.originalFilename)
-            minioService.uploadFile(file.originalFilename, file.inputStream)
+            minioService.uploadFile(file.originalFilename, file.inputStream, file.size)
             return buildResponse(HttpStatus.OK, "File uploaded")
         } catch (IllegalArgumentException e) {
             return buildResponse(HttpStatus.BAD_REQUEST, e.message)
@@ -39,11 +39,13 @@ class FileService {
             def stream = minioService.downloadFile(fileName)
             if (!stream) return buildResponse(HttpStatus.NOT_FOUND, "File not found")
 
-            def resource = new ByteArrayResource(stream.readAllBytes())
-            return ResponseEntity.ok()
-                    .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=$fileName")
-                    .contentType(MediaType.APPLICATION_OCTET_STREAM)
-                    .body(resource)
+            try (stream) {
+                def resource = new ByteArrayResource(stream.readAllBytes())
+                return ResponseEntity.ok()
+                        .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=$fileName")
+                        .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                        .body(resource)
+            }
         } catch (IllegalArgumentException e) {
             return buildResponse(HttpStatus.BAD_REQUEST, e.message)
         } catch (Exception e) {

--- a/apps/api/src/main/groovy/org/nobuddy/thrashbuddy/service/K8sService.groovy
+++ b/apps/api/src/main/groovy/org/nobuddy/thrashbuddy/service/K8sService.groovy
@@ -19,8 +19,10 @@ class K8sService {
     private static final String NAMESPACE = System.getenv("NAMESPACE")
     private static final String JOB_NAME = "${System.getenv("APP_NAME")}-job"
 
-    StatusService.ResponseStatus status = StatusService.ResponseStatus.IDLE
-    String errorMessage = null
+    private static final long MAX_MONITOR_DURATION_MILLIS = 30 * 60 * 1000
+
+    volatile StatusService.ResponseStatus status = StatusService.ResponseStatus.IDLE
+    volatile String errorMessage = null
 
     @Autowired
     KubernetesClient client
@@ -41,6 +43,7 @@ class K8sService {
             monitorPodsAndStopIfLow(count)
             status = StatusService.ResponseStatus.IDLE
         } catch (Exception e) {
+            log.error("Failed to start jobs for $JOB_NAME", e)
             status = StatusService.ResponseStatus.ERROR
             errorMessage = "Failed to start jobs: ${e.message}"
         }
@@ -53,6 +56,7 @@ class K8sService {
             deleteK6Jobs()
             status = StatusService.ResponseStatus.IDLE
         } catch (Exception e) {
+            log.error("Failed to stop jobs for $JOB_NAME", e)
             status = StatusService.ResponseStatus.ERROR
             errorMessage = "Failed to stop jobs: ${e.message}"
         }
@@ -119,7 +123,17 @@ class K8sService {
         int threshold = (int) (parallelism * 0.25)
         boolean isRunning = false
         def noRunningSince = System.currentTimeMillis()
+        def monitorStarted = System.currentTimeMillis()
         while (true) {
+            if (System.currentTimeMillis() - monitorStarted > MAX_MONITOR_DURATION_MILLIS) {
+                log.warn("Pod monitor for $JOB_NAME exceeded max duration, stopping jobs and giving up")
+                try {
+                    deleteK6Jobs()
+                } catch (Exception e) {
+                    log.error("Failed deleting jobs after monitor timeout", e)
+                }
+                break
+            }
             try {
                 def pods = client.pods()
                         .inNamespace(NAMESPACE)

--- a/apps/api/src/main/groovy/org/nobuddy/thrashbuddy/service/MinioService.groovy
+++ b/apps/api/src/main/groovy/org/nobuddy/thrashbuddy/service/MinioService.groovy
@@ -16,11 +16,11 @@ class MinioService {
         this.bucketName = bucketName
     }
 
-    void uploadFile(String objectName, InputStream fileStream) {
+    void uploadFile(String objectName, InputStream fileStream, long size) {
         minioClient.putObject(PutObjectArgs.builder()
                 .bucket(bucketName)
                 .object(objectName)
-                .stream(fileStream, fileStream.available(), -1)
+                .stream(fileStream, size, -1)
                 .build())
     }
 

--- a/apps/api/src/main/groovy/org/nobuddy/thrashbuddy/service/StatusService.groovy
+++ b/apps/api/src/main/groovy/org/nobuddy/thrashbuddy/service/StatusService.groovy
@@ -8,6 +8,32 @@ class StatusService {
         IDLE, RUNNING, STOPPING, ERROR, INIT
     }
 
-    ResponseStatus status = ResponseStatus.INIT
-    String errorMessage = ""
+    private volatile ResponseStatus status = ResponseStatus.INIT
+    private volatile String errorMessage = ""
+
+    synchronized ResponseStatus getStatus() {
+        status
+    }
+
+    synchronized void setStatus(ResponseStatus newStatus) {
+        status = newStatus
+    }
+
+    synchronized String getErrorMessage() {
+        errorMessage
+    }
+
+    synchronized void setErrorMessage(String message) {
+        errorMessage = message
+    }
+
+    // Atomically applies newStatus only if the current status is still expected,
+    // closing the check-then-act race between reading status and transitioning it.
+    synchronized boolean compareAndSet(ResponseStatus expected, ResponseStatus newStatus) {
+        if (status != expected) {
+            return false
+        }
+        status = newStatus
+        return true
+    }
 }

--- a/apps/api/src/main/groovy/org/nobuddy/thrashbuddy/service/TestExecutionService.groovy
+++ b/apps/api/src/main/groovy/org/nobuddy/thrashbuddy/service/TestExecutionService.groovy
@@ -71,7 +71,9 @@ class TestExecutionService {
             return buildResponse(HttpStatus.BAD_REQUEST, StatusService.ResponseStatus.ERROR, e.message)
         }
 
-        statusService.setStatus(StatusService.ResponseStatus.RUNNING)
+        if (!statusService.compareAndSet(StatusService.ResponseStatus.IDLE, StatusService.ResponseStatus.RUNNING)) {
+            return buildResponse(HttpStatus.BAD_REQUEST, StatusService.ResponseStatus.ERROR, "Cannot start while not idle")
+        }
         k8sService.start(cpu, memory, loadAgents, envVars)
 
         return buildResponse(HttpStatus.OK, StatusService.ResponseStatus.RUNNING, "K6 test started with $loadAgents agents")
@@ -95,7 +97,9 @@ class TestExecutionService {
             return buildResponse(HttpStatus.BAD_REQUEST, StatusService.ResponseStatus.ERROR, "Cannot stop while not running")
         }
 
-        statusService.setStatus(StatusService.ResponseStatus.STOPPING)
+        if (!statusService.compareAndSet(StatusService.ResponseStatus.RUNNING, StatusService.ResponseStatus.STOPPING)) {
+            return buildResponse(HttpStatus.BAD_REQUEST, StatusService.ResponseStatus.ERROR, "Cannot stop while not running")
+        }
         k8sService.stop()
 
         return buildResponse(HttpStatus.OK, StatusService.ResponseStatus.STOPPING, "Stopping all Kubernetes jobs...")

--- a/apps/api/src/test/groovy/org/nobuddy/thrashbuddy/service/FileServiceSpec.groovy
+++ b/apps/api/src/test/groovy/org/nobuddy/thrashbuddy/service/FileServiceSpec.groovy
@@ -19,7 +19,7 @@ class FileServiceSpec extends Specification {
             def response = fileService.handleUpload(file)
 
         then:
-            1 * minioService.uploadFile("test.txt", _)
+            1 * minioService.uploadFile("test.txt", _, "Hello".bytes.length)
             response.statusCode == HttpStatus.OK
             response.body.message == "File uploaded"
     }
@@ -32,7 +32,7 @@ class FileServiceSpec extends Specification {
             def response = fileService.handleUpload(file)
 
         then:
-            0 * minioService.uploadFile(_, _)
+            0 * minioService.uploadFile(_, _, _)
             response.statusCode == HttpStatus.BAD_REQUEST
             response.body.message.contains("Invalid file name")
     }
@@ -40,7 +40,7 @@ class FileServiceSpec extends Specification {
     def "handleUpload - failure"() {
         given:
             def file = new MockMultipartFile("file", "fail.txt", "text/plain", "Oops".bytes)
-            minioService.uploadFile(_, _) >> { throw new RuntimeException("Something went wrong") }
+            minioService.uploadFile(_, _, _) >> { throw new RuntimeException("Something went wrong") }
 
         when:
             def response = fileService.handleUpload(file)

--- a/apps/api/src/test/groovy/org/nobuddy/thrashbuddy/service/MinioServiceSpec.groovy
+++ b/apps/api/src/test/groovy/org/nobuddy/thrashbuddy/service/MinioServiceSpec.groovy
@@ -30,7 +30,7 @@ class MinioServiceSpec extends Specification {
             def stream = new ByteArrayInputStream(content.bytes)
 
         when:
-            minioService.uploadFile("test.txt", stream)
+            minioService.uploadFile("test.txt", stream, content.bytes.length)
 
         then:
             1 * minioClient.putObject(_ as PutObjectArgs)


### PR DESCRIPTION
## Summary
Fixes the API-side reliability findings from a full-repo review (follow-up to the merged security PRs):

- **`StatusService`**: `status`/`errorMessage` are now `volatile` with `synchronized` accessors, plus a new `compareAndSet()` for atomic state transitions.
- **`TestExecutionService`**: `startTest()`/`stopTest()` now use `compareAndSet` at the actual point of transition instead of a separate check-then-set, closing the race where two concurrent requests could both pass the initial idle/running check and both trigger `k8sService.start()`/`stop()`.
- **`K8sService`**: `status`/`errorMessage` are written by the `@Async` executor thread and read by request threads with no prior synchronization — marked `volatile` for a proper memory barrier. Exceptions in `start()`/`stop()` are now logged (`log.error`) instead of only being stashed in `errorMessage` and discarded. The pod-monitoring loop now gives up and stops the job after 30 minutes instead of potentially running forever if pod count never drops below the threshold.
- **`AsyncConfig`**: replaced the unbounded `newCachedThreadPool` with a fixed pool of 2 threads — only start/stop are ever submitted here.
- **`FileService.handleDownload`**: closes the MinIO `InputStream` via try-with-resources instead of leaking it on every download.
- **`MinioService.uploadFile`**: now takes and uses the real file size instead of `InputStream.available()`, which isn't a reliable byte count for a stream and could misreport size for larger uploads.

Closes #293, #294, #295

## Test plan
- [x] `./gradlew clean test jacocoTestReport` (via `gradle:9.6.1-jdk21` container): all tests pass, including updated specs for the new `uploadFile(name, stream, size)` signature
- [x] Built the API Docker image and ran a live upload → status → download → delete cycle against a real MinIO instance: upload succeeds, downloaded content matches the original byte-for-byte (1062/1062 bytes), delete succeeds