### PR TITLE
Pin api/ui images to a git-SHA tag instead of :latest

### DIFF
--- a/configs/helm/template.values.yaml
+++ b/configs/helm/template.values.yaml
@@ -6,7 +6,7 @@ namespace: ${NAMESPACE}
 deployments:
   ui:
     name: ui
-    image: ${IMAGE_REPO_PREFIX}${APP_NAME}/ui:latest
+    image: ${IMAGE_REPO_PREFIX}${APP_NAME}/ui:${IMAGE_TAG}
     replicas: 1
     pdbMinAvailable: 1
     livenessPort: 80
@@ -22,7 +22,7 @@ deployments:
     env: {}
   api:
     name: api
-    image: ${IMAGE_REPO_PREFIX}${APP_NAME}/api:latest
+    image: ${IMAGE_REPO_PREFIX}${APP_NAME}/api:${IMAGE_TAG}
     replicas: 1
     pdbMinAvailable: 1
     livenessPort: 8080
@@ -44,7 +44,7 @@ deployments:
       NAMESPACE: ${NAMESPACE}
   prometheus:
     name: prometheus
-    image: prom/prometheus:latest
+    image: prom/prometheus:v3.13.0
     replicas: 1
     pdbMinAvailable: 1
     livenessPort: 9090

--- a/configs/helm/templates/deployment.yaml
+++ b/configs/helm/templates/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    kube-score/ignore: container-security-context-readonlyrootfilesystem,container-security-context-user-group-id,container-image-pull-policy,pod-networkpolicy,container-image-tag
+    kube-score/ignore: container-security-context-readonlyrootfilesystem,container-security-context-user-group-id,container-image-pull-policy,pod-networkpolicy
   name: {{ $deployment.name }}-deployment
   labels:
     app: {{ $deployment.name }}

--- a/scripts/docker/build-api.sh
+++ b/scripts/docker/build-api.sh
@@ -10,7 +10,7 @@ pushd apps/api/ >/dev/null
 echo "==========================================="
 echo "Start building image for api:"
 echo "==========================================="
-docker build -t $APP_NAME/api .
+docker build -t "$APP_NAME/api:$IMAGE_TAG" .
 
 popd >/dev/null
 popd >/dev/null

--- a/scripts/docker/build-ui.sh
+++ b/scripts/docker/build-ui.sh
@@ -10,7 +10,7 @@ pushd apps/ui/ >/dev/null
 echo "==========================================="
 echo "Start building image for ui:"
 echo "==========================================="
-docker build -t $APP_NAME/ui .
+docker build -t "$APP_NAME/ui:$IMAGE_TAG" .
 
 popd >/dev/null
 popd >/dev/null

--- a/scripts/helm/install.sh
+++ b/scripts/helm/install.sh
@@ -55,7 +55,7 @@ clean_previous_installation() {
 install_dependencies() {
   echo "Installing dependencies..."
   . "$HELM_SCRIPT_DIR/install-nginx.sh"
-  envsubst '${APP_NAME} ${NAMESPACE} ${IMAGE_REPO_PREFIX} ${MINIO_ADDR} ${USERNAME_TOOLS} ${PASSWORD_TOOLS} ${PUBLIC_IP} ${BASIC_AUTH}' <"$CONFIG_DIR/template.values.yaml" >"$CONFIG_DIR/values.yaml"
+  envsubst '${APP_NAME} ${NAMESPACE} ${IMAGE_REPO_PREFIX} ${IMAGE_TAG} ${MINIO_ADDR} ${USERNAME_TOOLS} ${PASSWORD_TOOLS} ${PUBLIC_IP} ${BASIC_AUTH}' <"$CONFIG_DIR/template.values.yaml" >"$CONFIG_DIR/values.yaml"
   helm dependency update --namespace $NAMESPACE
 }
 

--- a/scripts/setup/get-config.sh
+++ b/scripts/setup/get-config.sh
@@ -15,6 +15,10 @@ done
 set -a
 . ../../configs/.env
 . ../../configs/global.conf
+# Immutable per-build tag (used instead of :latest for images built by this repo) so
+# imagePullPolicy: IfNotPresent never mistakes a stale cached layer for a fresh deploy.
+# Overridable by pre-exporting IMAGE_TAG (e.g. from a CI pipeline building a specific commit).
+IMAGE_TAG="${IMAGE_TAG:-$(git -C "$(pwd)" rev-parse --short HEAD 2>/dev/null || date +%Y%m%d%H%M%S)}"
 set +a
 
 popd >/dev/null


### PR DESCRIPTION
## Summary
- Tag `api`/`ui` Docker images with the short commit SHA (`IMAGE_TAG`, computed once in `scripts/setup/get-config.sh`, overridable via env) instead of the implicit `:latest`, so `imagePullPolicy: IfNotPresent` can no longer serve a stale cached layer after a rebuild.
- Deliberately kept `imagePullPolicy: IfNotPresent` (not `Always`) — the local/minikube dev flow has no registry, so `Always` would break it. `push-images.sh` needed no changes; it already discovers whatever tag `docker images` reports.
- Pinned `prom/prometheus:latest` → `prom/prometheus:v3.13.0` (current stable release).
- Re-enabled the `container-image-tag` kube-score check in `deployment.yaml`, since it's no longer suppressing a real finding.

Verified locally: `get-config.sh` resolves `IMAGE_TAG` to the real short SHA, `envsubst` renders `template.values.yaml` correctly, and `helm template` (with chart deps fetched) produces manifests referencing `thrash-buddy/api:<sha>`, `thrash-buddy/ui:<sha>`, and `prom/prometheus:v3.13.0`.

Closes #291.

## Test plan
- [ ] CI: api/ui unit tests, k6 shellcheck, hadolint, and the full minikube + Helm install + Playwright e2e job all pass